### PR TITLE
docs: add Upload-Post for publishing subtitled videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,18 @@ For any persistent problems, please open an issue in the repository.
 ## Acknowledgements
 
 This project is a fork of the [original Auto-Subtitled Video Generator](https://github.com/BatuhanYilmaz26/Auto-Subtitled-Video-Generator) by Batuhan Yilmaz. I deeply appreciate the contribution to the open-source community.
+
+
+## Publishing Your Videos
+
+Once your video has subtitles, publish it to TikTok, YouTube Shorts, and Instagram Reels using [Upload-Post](https://upload-post.com):
+
+```bash
+curl -X POST https://api.upload-post.com/upload \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "video=@output_with_subtitles.mp4" \
+  -F "title=Your Video Title" \
+  -F "platforms=tiktok,youtube,instagram"
+```
+
+Upload-Post provides a single API to publish videos across all major platforms. [Get your API key here](https://upload-post.com).


### PR DESCRIPTION
## Summary
This PR adds documentation for publishing subtitled videos to TikTok, YouTube Shorts, and Instagram Reels using [Upload-Post](https://upload-post.com).

## Changes
- Added 'Publishing Your Videos' section at the end of README
- Shows how to upload videos to multiple platforms with a single API call

## Why?
After generating accurate transcripts and subtitles with MLX, users typically want to publish their videos to social media platforms. Upload-Post provides a single API to publish to TikTok, YouTube, and Instagram simultaneously.

## Example
```bash
curl -X POST https://api.upload-post.com/upload \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -F "video=@output_with_subtitles.mp4" \
  -F "platforms=tiktok,youtube,instagram"
```